### PR TITLE
Print a winning assignment to the outermost block

### DIFF
--- a/src/ZigZag.cpp
+++ b/src/ZigZag.cpp
@@ -106,7 +106,19 @@ lbool ZigZag::solve_(int confl_budget) {
          if(verb)std::cerr<<"conflicts:"<<conflict_count<<std::endl;
          const int bt=solvers[lev]->analyze();
          if(verb)std::cerr<<"bt:"<<bt<<std::endl;
-         if(bt<0) return qt==UNIVERSAL ? l_True : l_False;
+         if(bt<0) {
+           if (levels.level_type(0) != qt) {
+             printf("v");
+             //for (Var v : solvers[0]->get_dom_vars()) {
+             for (Var v : formula.pref[0].second) {
+               if (solvers[0]->val(v) == l_True) {
+                 printf(" %d", v);
+               }
+             }
+             printf(" 0\n");
+           }
+           return qt==UNIVERSAL ? l_True : l_False;
+         }
          const size_t btx=(size_t)bt;
          Substitution opp;
          while(trail.size()) {


### PR DESCRIPTION
I heard some people complain at the QBF workshop that circuit solvers don't give winning moves for the outermost block, and since I was already hacking CQesto for something else and found the same need, I thought I'd try to implement it. I hope this code does it correctly. AFAICT `qt` is the losing player, so if level zero is the opposite player, reconstruct the current assignment to level zero and print it. Tested briefly, it looked OK.